### PR TITLE
chore: KDA Roles improvements

### DIFF
--- a/framework/scenario/src/facade/world_tx/scenario_set_state.rs
+++ b/framework/scenario/src/facade/world_tx/scenario_set_state.rs
@@ -56,14 +56,15 @@ impl ScenarioWorld {
     {
         let env = self.new_env_data();
         let address_value = address_annotated(&env, &address);
-        let accounts = &mut self.get_mut_state().accounts;
-        for (vm_address, account) in accounts.iter_mut() {
-            if vm_address == &address_value.to_vm_address() {
-                account.kda.set_roles(
-                    token_id.to_vec(),
-                    roles.iter().map(|role| role.clone().into_bytes()).collect(),
-                );
-            }
+        if let Some(acc) = self
+            .get_mut_state()
+            .accounts
+            .get_mut(&address_value.to_vm_address())
+        {
+            acc.kda.set_roles(
+                token_id.to_vec(),
+                roles.into_iter().map(|r| r.into_bytes()).collect(),
+            );
         }
     }
 
@@ -79,12 +80,10 @@ impl ScenarioWorld {
         let env = self.new_env_data();
         let address_value = address_annotated(&env, &address);
         let accounts = &mut self.get_mut_state().accounts;
-        for (vm_address, account) in accounts.iter_mut() {
-            if vm_address == &address_value.to_vm_address() {
-                account
-                    .kda
-                    .set_can_burn(token_id.to_vec(), token_nonce, can_burn);
-            }
+        if let Some(account) = accounts.get_mut(&address_value.to_vm_address()) {
+            account
+                .kda
+                .set_can_burn(token_id.to_vec(), token_nonce, can_burn);
         }
     }
 }

--- a/framework/scenario/src/whitebox_legacy/contract_obj_wrapper.rs
+++ b/framework/scenario/src/whitebox_legacy/contract_obj_wrapper.rs
@@ -15,7 +15,7 @@ use crate::{
 use klever_chain_scenario_format::interpret_trait::InterpretableFrom;
 use klever_chain_vm::{
     tx_mock::{TxContext, TxContextStack, TxFunctionName, TxResult},
-    types::VMAddress,
+    types::{KDALocalRole, VMAddress},
     world_mock::KdaInstanceMetadata,
 };
 use klever_sc::types::H256;
@@ -481,16 +481,16 @@ impl BlockchainStateWrapper {
             Some(acc) => {
                 let mut roles_raw = Vec::new();
                 if allow_mint {
-                    roles_raw.push(b"mint".to_vec());
+                    roles_raw.push(KDALocalRole::Mint.as_role_name().to_vec());
                 }
                 if allow_set_ito_price {
-                    roles_raw.push(b"set_ito_price".to_vec());
+                    roles_raw.push(KDALocalRole::SetITOPrices.as_role_name().to_vec());
                 }
                 if allow_deposit {
-                    roles_raw.push(b"deposit".to_vec());
+                    roles_raw.push(KDALocalRole::Deposit.as_role_name().to_vec());
                 }
                 if allow_transfer {
-                    roles_raw.push(b"transfer".to_vec());
+                    roles_raw.push(KDALocalRole::Transfer.as_role_name().to_vec());
                 }
                 acc.kda.set_roles(token_id.to_vec(), roles_raw);
 

--- a/vm/src/types/kda_local_role.rs
+++ b/vm/src/types/kda_local_role.rs
@@ -55,8 +55,6 @@ impl KDALocalRole {
     }
 }
 
-// TODO: can be done with macros, but I didn't find a public library that does it and is no_std
-// we can implement it, it's easy
 const ALL_ROLES: [KDALocalRole; 4] = [
     KDALocalRole::Mint,
     KDALocalRole::SetITOPrices,


### PR DESCRIPTION
## Summary
This PR improves the handling of KDA roles by using constants instead of string literals and the use of direct access to hash maps instead of iterating it.