### PR TITLE
[KLC-1616] Add events to Admin module

### DIFF
--- a/contracts/feature-tests/use-module/use_module_expected_main.abi.json
+++ b/contracts/feature-tests/use-module/use_module_expected_main.abi.json
@@ -282,6 +282,36 @@
                     "indexed": true
                 }
             ]
+        },
+        {
+            "identifier": "admin_added",
+            "inputs": [
+                {
+                    "name": "caller",
+                    "type": "Address",
+                    "indexed": true
+                },
+                {
+                    "name": "new_admin",
+                    "type": "Address",
+                    "indexed": true
+                }
+            ]
+        },
+        {
+            "identifier": "admin_removed",
+            "inputs": [
+                {
+                    "name": "caller",
+                    "type": "Address",
+                    "indexed": true
+                },
+                {
+                    "name": "removed_admin",
+                    "type": "Address",
+                    "indexed": true
+                }
+            ]
         }
     ],
     "kdaAttributes": [

--- a/contracts/feature-tests/use-module/use_module_expected_view.abi.json
+++ b/contracts/feature-tests/use-module/use_module_expected_view.abi.json
@@ -71,6 +71,36 @@
                     "indexed": true
                 }
             ]
+        },
+        {
+            "identifier": "admin_added",
+            "inputs": [
+                {
+                    "name": "caller",
+                    "type": "Address",
+                    "indexed": true
+                },
+                {
+                    "name": "new_admin",
+                    "type": "Address",
+                    "indexed": true
+                }
+            ]
+        },
+        {
+            "identifier": "admin_removed",
+            "inputs": [
+                {
+                    "name": "caller",
+                    "type": "Address",
+                    "indexed": true
+                },
+                {
+                    "name": "removed_admin",
+                    "type": "Address",
+                    "indexed": true
+                }
+            ]
         }
     ],
     "kdaAttributes": [

--- a/contracts/modules/src/only_admin.rs
+++ b/contracts/modules/src/only_admin.rs
@@ -10,15 +10,25 @@ pub trait OnlyAdminModule {
     #[only_owner]
     #[endpoint(addAdmin)]
     fn add_admin(&self, address: ManagedAddress) {
-        self.admins().insert(address);
-        // TODO: event
+        let caller = self.blockchain().get_caller();
+        let epoch = self.blockchain().get_block_epoch();
+        let timestamp = self.blockchain().get_block_timestamp();
+
+        self.admins().insert(address.clone());
+
+        self.admin_added_event(&caller, epoch, timestamp, &address);
     }
 
     #[only_owner]
     #[endpoint(removeAdmin)]
     fn remove_admin(&self, address: ManagedAddress) {
+        let caller = self.blockchain().get_caller();
+        let epoch = self.blockchain().get_block_epoch();
+        let timestamp = self.blockchain().get_block_timestamp();
+
         self.admins().swap_remove(&address);
-        // TODO: event
+
+        self.admin_removed_event(&caller, epoch, timestamp, &address);
     }
 
     #[view(getAdmins)]
@@ -31,4 +41,22 @@ pub trait OnlyAdminModule {
             "Endpoint can only be called by admins"
         );
     }
+
+    #[event("admin_added")]
+    fn admin_added_event(
+        &self,
+        #[indexed] caller: &ManagedAddress,
+        #[indexed] epoch: u64,
+        #[indexed] timestamp: u64,
+        #[indexed] new_admin: &ManagedAddress,
+    );
+
+    #[event("admin_removed")]
+    fn admin_removed_event(
+        &self,
+        #[indexed] caller: &ManagedAddress,
+        #[indexed] epoch: u64,
+        #[indexed] timestamp: u64,
+        #[indexed] removed_admin: &ManagedAddress,
+    );
 }

--- a/contracts/modules/src/only_admin.rs
+++ b/contracts/modules/src/only_admin.rs
@@ -11,24 +11,18 @@ pub trait OnlyAdminModule {
     #[endpoint(addAdmin)]
     fn add_admin(&self, address: ManagedAddress) {
         let caller = self.blockchain().get_caller();
-        let epoch = self.blockchain().get_block_epoch();
-        let timestamp = self.blockchain().get_block_timestamp();
-
         self.admins().insert(address.clone());
 
-        self.admin_added_event(&caller, epoch, timestamp, &address);
+        self.admin_added_event(&caller, &address);
     }
 
     #[only_owner]
     #[endpoint(removeAdmin)]
     fn remove_admin(&self, address: ManagedAddress) {
         let caller = self.blockchain().get_caller();
-        let epoch = self.blockchain().get_block_epoch();
-        let timestamp = self.blockchain().get_block_timestamp();
-
         self.admins().swap_remove(&address);
 
-        self.admin_removed_event(&caller, epoch, timestamp, &address);
+        self.admin_removed_event(&caller, &address);
     }
 
     #[view(getAdmins)]
@@ -46,8 +40,6 @@ pub trait OnlyAdminModule {
     fn admin_added_event(
         &self,
         #[indexed] caller: &ManagedAddress,
-        #[indexed] epoch: u64,
-        #[indexed] timestamp: u64,
         #[indexed] new_admin: &ManagedAddress,
     );
 
@@ -55,8 +47,6 @@ pub trait OnlyAdminModule {
     fn admin_removed_event(
         &self,
         #[indexed] caller: &ManagedAddress,
-        #[indexed] epoch: u64,
-        #[indexed] timestamp: u64,
         #[indexed] removed_admin: &ManagedAddress,
     );
 }


### PR DESCRIPTION
This pull request improves the `OnlyAdminModule` in `contracts/modules/src/only_admin.rs` by adding event emission for admin management actions. Now, when an admin is added or removed, a corresponding event is emitted, making the contract more transparent and easier to track changes.

**Event emission for admin management:**

* Added `admin_added_event` and `admin_removed_event` functions to emit events when an admin is added or removed, including indexed parameters for the caller and affected admin addresses.
* Updated the `add_admin` and `remove_admin` endpoints to emit the respective events after modifying the admin list.