### PR TITLE
Fix mismatched lifetime syntaxes

### DIFF
--- a/framework/base/src/storage/mappers/bi_di_mapper.rs
+++ b/framework/base/src/storage/mappers/bi_di_mapper.rs
@@ -123,15 +123,15 @@ where
         self.value_set_mapper.contains(value)
     }
 
-    pub fn get_all_values(&self) -> unordered_set_mapper::Iter<SA, V, A> {
+    pub fn get_all_values(&self) -> unordered_set_mapper::Iter<'_, SA, V, A> {
         self.value_set_mapper.iter()
     }
 
-    pub fn get_all_ids(&self) -> unordered_set_mapper::Iter<SA, K, A> {
+    pub fn get_all_ids(&self) -> unordered_set_mapper::Iter<'_, SA, K, A> {
         self.id_set_mapper.iter()
     }
 
-    pub fn iter(&self) -> Iter<SA, K, V, A> {
+    pub fn iter(&self) -> Iter<'_, SA, K, V, A> {
         Iter::new(self)
     }
 

--- a/framework/base/src/storage/mappers/linked_list_mapper.rs
+++ b/framework/base/src/storage/mappers/linked_list_mapper.rs
@@ -217,11 +217,11 @@ where
         Some(self.get_node(node_id))
     }
 
-    pub fn iter(&self) -> Iter<SA, T, A> {
+    pub fn iter(&self) -> Iter<'_, SA, T, A> {
         Iter::new(self)
     }
 
-    pub fn iter_from_node_id(&self, node_id: u32) -> Iter<SA, T, A> {
+    pub fn iter_from_node_id(&self, node_id: u32) -> Iter<'_, SA, T, A> {
         Iter::new_from_node_id(self, node_id)
     }
 

--- a/framework/base/src/storage/mappers/map_mapper.rs
+++ b/framework/base/src/storage/mappers/map_mapper.rs
@@ -164,7 +164,7 @@ where
         None
     }
 
-    pub fn keys(&self) -> Keys<SA, A, K> {
+    pub fn keys(&self) -> Keys<'_, SA, A, K> {
         self.keys_set.iter()
     }
 
@@ -197,13 +197,13 @@ where
 
     /// An iterator visiting all values in arbitrary order.
     /// The iterator element type is `&'a V`.
-    pub fn values(&self) -> Values<SA, A, K, V> {
+    pub fn values(&self) -> Values<'_, SA, A, K, V> {
         Values::new(self)
     }
 
     /// An iterator visiting all key-value pairs in arbitrary order.
     /// The iterator element type is `(&'a K, &'a V)`.
-    pub fn iter(&self) -> Iter<SA, A, K, V> {
+    pub fn iter(&self) -> Iter<'_, SA, A, K, V> {
         Iter::new(self)
     }
 }

--- a/framework/base/src/storage/mappers/map_storage_mapper.rs
+++ b/framework/base/src/storage/mappers/map_storage_mapper.rs
@@ -130,7 +130,7 @@ where
         None
     }
 
-    pub fn keys(&self) -> Keys<SA, A, K> {
+    pub fn keys(&self) -> Keys<'_, SA, A, K> {
         self.keys_set.iter()
     }
 
@@ -150,7 +150,7 @@ where
     }
 
     /// Gets the given key's corresponding entry in the map for in-place manipulation.
-    pub fn entry(&mut self, key: K) -> Entry<SA, A, K, V> {
+    pub fn entry(&mut self, key: K) -> Entry<'_, SA, A, K, V> {
         if self.contains_key(&key) {
             Entry::Occupied(OccupiedEntry {
                 key,
@@ -168,13 +168,13 @@ where
 
     /// An iterator visiting all values in arbitrary order.
     /// The iterator element type is `&'a V`.
-    pub fn values(&self) -> Values<SA, A, K, V> {
+    pub fn values(&self) -> Values<'_, SA, A, K, V> {
         Values::new(self)
     }
 
     /// An iterator visiting all key-value pairs in arbitrary order.
     /// The iterator element type is `(&'a K, &'a V)`.
-    pub fn iter(&self) -> Iter<SA, A, K, V> {
+    pub fn iter(&self) -> Iter<'_, SA, A, K, V> {
         Iter::new(self)
     }
 }

--- a/framework/base/src/storage/mappers/queue_mapper.rs
+++ b/framework/base/src/storage/mappers/queue_mapper.rs
@@ -305,11 +305,11 @@ where
         name_key
     }
 
-    pub fn iter(&self) -> Iter<SA, A, T> {
+    pub fn iter(&self) -> Iter<'_, SA, A, T> {
         Iter::new(self)
     }
 
-    pub fn iter_from_node_id(&self, node_id: u32) -> Iter<SA, A, T> {
+    pub fn iter_from_node_id(&self, node_id: u32) -> Iter<'_, SA, A, T> {
         Iter::new_from_node_id(self, node_id)
     }
 

--- a/framework/base/src/storage/mappers/set_mapper.rs
+++ b/framework/base/src/storage/mappers/set_mapper.rs
@@ -182,11 +182,11 @@ where
 
     /// An iterator visiting all elements in arbitrary order.
     /// The iterator element type is `&'a T`.
-    pub fn iter(&self) -> Iter<SA, A, T> {
+    pub fn iter(&self) -> Iter<'_, SA, A, T> {
         self.queue_mapper.iter()
     }
 
-    pub fn iter_from(&self, value: &T) -> Iter<SA, A, T> {
+    pub fn iter_from(&self, value: &T) -> Iter<'_, SA, A, T> {
         let node_id = self.get_node_id(value);
         self.queue_mapper.iter_from_node_id(node_id)
     }

--- a/framework/base/src/storage/mappers/token/fungible_token_mapper.rs
+++ b/framework/base/src/storage/mappers/token/fungible_token_mapper.rs
@@ -43,7 +43,7 @@ impl<SA> StorageTokenWrapper<SA> for FungibleTokenMapper<SA>
 where
     SA: StorageMapperApi + CallTypeApi,
 {
-    fn get_storage_key(&self) -> crate::types::ManagedRef<SA, StorageKey<SA>> {
+    fn get_storage_key(&self) -> crate::types::ManagedRef<'_, SA, StorageKey<SA>> {
         self.key.as_ref()
     }
 

--- a/framework/base/src/storage/mappers/token/non_fungible_token_mapper.rs
+++ b/framework/base/src/storage/mappers/token/non_fungible_token_mapper.rs
@@ -44,7 +44,7 @@ impl<SA> StorageTokenWrapper<SA> for NonFungibleTokenMapper<SA>
 where
     SA: StorageMapperApi + CallTypeApi,
 {
-    fn get_storage_key(&self) -> crate::types::ManagedRef<SA, StorageKey<SA>> {
+    fn get_storage_key(&self) -> crate::types::ManagedRef<'_, SA, StorageKey<SA>> {
         self.key.as_ref()
     }
 

--- a/framework/base/src/storage/mappers/token/semi_fungible_token_mapper.rs
+++ b/framework/base/src/storage/mappers/token/semi_fungible_token_mapper.rs
@@ -44,7 +44,7 @@ impl<SA> StorageTokenWrapper<SA> for SemiFungibleTokenMapper<SA>
 where
     SA: StorageMapperApi + CallTypeApi,
 {
-    fn get_storage_key(&self) -> crate::types::ManagedRef<SA, StorageKey<SA>> {
+    fn get_storage_key(&self) -> crate::types::ManagedRef<'_, SA, StorageKey<SA>> {
         self.key.as_ref()
     }
 

--- a/framework/base/src/storage/mappers/token/token_mapper.rs
+++ b/framework/base/src/storage/mappers/token/token_mapper.rs
@@ -18,7 +18,7 @@ pub trait StorageTokenWrapper<SA>
 where
     SA: StorageMapperApi + CallTypeApi,
 {
-    fn get_storage_key(&self) -> ManagedRef<SA, StorageKey<SA>>;
+    fn get_storage_key(&self) -> ManagedRef<'_, SA, StorageKey<SA>>;
 
     fn is_empty(&self) -> bool {
         storage_get_len(self.get_storage_key()) == 0

--- a/framework/base/src/storage/mappers/unique_id_mapper.rs
+++ b/framework/base/src/storage/mappers/unique_id_mapper.rs
@@ -81,7 +81,7 @@ where
         }
     }
     /// Provides a forward iterator.
-    pub fn iter(&self) -> Iter<SA, A> {
+    pub fn iter(&self) -> Iter<'_, SA, A> {
         Iter::new(self)
     }
 }

--- a/framework/base/src/storage/mappers/unordered_set_mapper.rs
+++ b/framework/base/src/storage/mappers/unordered_set_mapper.rs
@@ -117,7 +117,7 @@ where
 
     /// An iterator visiting all elements in arbitrary order.
     /// The iterator element type is `&'a T`.
-    pub fn iter(&self) -> Iter<SA, T, A> {
+    pub fn iter(&self) -> Iter<'_, SA, T, A> {
         self.vec_mapper.iter()
     }
 }

--- a/framework/base/src/storage/mappers/vec_mapper.rs
+++ b/framework/base/src/storage/mappers/vec_mapper.rs
@@ -162,7 +162,7 @@ where
     }
 
     /// Provides a forward iterator.
-    pub fn iter(&self) -> Iter<SA, T, A> {
+    pub fn iter(&self) -> Iter<'_, SA, T, A> {
         Iter::new(self)
     }
 }

--- a/framework/base/src/types/interaction/managed_arg_buffer.rs
+++ b/framework/base/src/types/interaction/managed_arg_buffer.rs
@@ -174,7 +174,7 @@ where
         self.data
     }
 
-    pub fn iter_buffers(&self) -> ManagedVecRefIterator<M, ManagedBuffer<M>> {
+    pub fn iter_buffers(&self) -> ManagedVecRefIterator<'_, M, ManagedBuffer<M>> {
         ManagedVecRefIterator::new(&self.data)
     }
 }
@@ -203,7 +203,7 @@ impl<M: ManagedTypeApi> ManagedArgBuffer<M>
 where
     M: ManagedTypeApi + 'static,
 {
-    pub fn raw_arg_iter(&self) -> ManagedVecRefIterator<M, ManagedBuffer<M>> {
+    pub fn raw_arg_iter(&self) -> ManagedVecRefIterator<'_, M, ManagedBuffer<M>> {
         self.data.iter()
     }
 }

--- a/framework/base/src/types/managed/multi_value/multi_value_managed_vec.rs
+++ b/framework/base/src/types/managed/multi_value/multi_value_managed_vec.rs
@@ -127,7 +127,7 @@ where
         self.0.with_self_as_vec(f)
     }
 
-    pub fn iter(&self) -> ManagedVecRefIterator<M, T> {
+    pub fn iter(&self) -> ManagedVecRefIterator<'_, M, T> {
         ManagedVecRefIterator::new(&self.0)
     }
 }

--- a/framework/base/src/types/managed/wrapped/managed_vec.rs
+++ b/framework/base/src/types/managed/wrapped/managed_vec.rs
@@ -173,7 +173,7 @@ where
         }
     }
 
-    pub fn get_mut(&mut self, index: usize) -> ManagedVecRef<M, T> {
+    pub fn get_mut(&mut self, index: usize) -> ManagedVecRef<'_, M, T> {
         ManagedVecRef::new(self.get_handle(), index)
     }
 
@@ -296,7 +296,7 @@ where
         result
     }
 
-    pub fn iter(&self) -> ManagedVecRefIterator<M, T> {
+    pub fn iter(&self) -> ManagedVecRefIterator<'_, M, T> {
         ManagedVecRefIterator::new(self)
     }
 

--- a/framework/base/src/types/static_buffer/sparse_array.rs
+++ b/framework/base/src/types/static_buffer/sparse_array.rs
@@ -116,7 +116,7 @@ where
         }
     }
 
-    pub fn iter(&self) -> SparseArrayIterator<E, CAPACITY> {
+    pub fn iter(&self) -> SparseArrayIterator<'_, E, CAPACITY> {
         SparseArrayIterator::new(self)
     }
 }

--- a/framework/scenario/src/debug_executor/contract_map.rs
+++ b/framework/scenario/src/debug_executor/contract_map.rs
@@ -74,7 +74,7 @@ impl ContractMapRef {
         ContractMapRef(Arc::new(Mutex::new(ContractMap::new())))
     }
 
-    pub fn lock(&self) -> MutexGuard<ContractMap> {
+    pub fn lock(&self) -> MutexGuard<'_, ContractMap> {
         self.0.lock().unwrap()
     }
 }

--- a/vm/src/tx_mock/tx_context.rs
+++ b/vm/src/tx_mock/tx_context.rs
@@ -125,15 +125,15 @@ impl TxContext {
         self.with_account_mut(&self.tx_input_box.to, f)
     }
 
-    pub fn m_types_lock(&self) -> MutexGuard<TxManagedTypes> {
+    pub fn m_types_lock(&self) -> MutexGuard<'_, TxManagedTypes> {
         self.managed_types.lock().unwrap()
     }
 
-    pub fn back_transfers_lock(&self) -> MutexGuard<BackTransfers> {
+    pub fn back_transfers_lock(&self) -> MutexGuard<'_, BackTransfers> {
         self.back_transfers.lock().unwrap()
     }
 
-    pub fn result_lock(&self) -> MutexGuard<TxResult> {
+    pub fn result_lock(&self) -> MutexGuard<'_, TxResult> {
         self.tx_result_cell.lock().unwrap()
     }
 
@@ -141,7 +141,7 @@ impl TxContext {
         std::mem::replace(&mut *self.tx_result_cell.lock().unwrap(), TxResult::empty())
     }
 
-    pub fn rng_lock(&self) -> MutexGuard<BlockchainRng> {
+    pub fn rng_lock(&self) -> MutexGuard<'_, BlockchainRng> {
         self.b_rng.lock().unwrap()
     }
 

--- a/vm/src/vm_hooks/vh_dispatcher.rs
+++ b/vm/src/vm_hooks/vh_dispatcher.rs
@@ -52,7 +52,7 @@ impl VMHooks for VMHooksDispatcher {
 
     fn signal_error(&self, message_offset: MemPtr, message_length: MemLength) {
         unsafe {
-            mem_conv::with_bytes(message_offset, message_length, |message| {
+            mem_conv::with_bytes::<_, ()>(message_offset, message_length, |message| {
                 self.handler.signal_error(message);
             });
         }

--- a/vm/src/vm_hooks/vh_impl/vh_debug_api.rs
+++ b/vm/src/vm_hooks/vh_impl/vh_debug_api.rs
@@ -33,7 +33,7 @@ impl DebugApiVMHooksHandler {
 }
 
 impl VMHooksHandlerSource for DebugApiVMHooksHandler {
-    fn m_types_lock(&self) -> MutexGuard<TxManagedTypes> {
+    fn m_types_lock(&self) -> MutexGuard<'_, TxManagedTypes> {
         self.0.m_types_lock()
     }
 
@@ -54,7 +54,7 @@ impl VMHooksHandlerSource for DebugApiVMHooksHandler {
         self.0.rng_lock().next_bytes(length)
     }
 
-    fn result_lock(&self) -> MutexGuard<TxResult> {
+    fn result_lock(&self) -> MutexGuard<'_, TxResult> {
         self.0.result_lock()
     }
 
@@ -80,7 +80,7 @@ impl VMHooksHandlerSource for DebugApiVMHooksHandler {
         &self.0.blockchain_ref().current_block_info
     }
 
-    fn back_transfers_lock(&self) -> MutexGuard<BackTransfers> {
+    fn back_transfers_lock(&self) -> MutexGuard<'_, BackTransfers> {
         self.0.back_transfers_lock()
     }
 

--- a/vm/src/vm_hooks/vh_impl/vh_single_tx_api.rs
+++ b/vm/src/vm_hooks/vh_impl/vh_single_tx_api.rs
@@ -53,7 +53,7 @@ impl SingleTxApiVMHooksHandler {
 }
 
 impl VMHooksHandlerSource for SingleTxApiVMHooksHandler {
-    fn m_types_lock(&self) -> MutexGuard<TxManagedTypes> {
+    fn m_types_lock(&self) -> MutexGuard<'_, TxManagedTypes> {
         self.0.managed_types.lock().unwrap()
     }
 
@@ -69,7 +69,7 @@ impl VMHooksHandlerSource for SingleTxApiVMHooksHandler {
         panic!("cannot access the random bytes generator in the SingleTxApi")
     }
 
-    fn result_lock(&self) -> MutexGuard<TxResult> {
+    fn result_lock(&self) -> MutexGuard<'_, TxResult> {
         self.0.tx_result_cell.lock().unwrap()
     }
 
@@ -93,7 +93,7 @@ impl VMHooksHandlerSource for SingleTxApiVMHooksHandler {
         &self.0.current_block_info
     }
 
-    fn back_transfers_lock(&self) -> MutexGuard<BackTransfers> {
+    fn back_transfers_lock(&self) -> MutexGuard<'_, BackTransfers> {
         panic!("cannot access back transfers in the SingleTxApi")
     }
 

--- a/vm/src/vm_hooks/vh_impl/vh_static_api.rs
+++ b/vm/src/vm_hooks/vh_impl/vh_static_api.rs
@@ -24,7 +24,7 @@ impl StaticApiVMHooksHandler {
 }
 
 impl VMHooksHandlerSource for StaticApiVMHooksHandler {
-    fn m_types_lock(&self) -> MutexGuard<TxManagedTypes> {
+    fn m_types_lock(&self) -> MutexGuard<'_, TxManagedTypes> {
         self.0.lock().unwrap()
     }
 
@@ -44,7 +44,7 @@ impl VMHooksHandlerSource for StaticApiVMHooksHandler {
         panic!("cannot access the random bytes generator in the StaticApi")
     }
 
-    fn result_lock(&self) -> MutexGuard<TxResult> {
+    fn result_lock(&self) -> MutexGuard<'_, TxResult> {
         panic!("cannot access tx results in the StaticApi")
     }
 
@@ -68,7 +68,7 @@ impl VMHooksHandlerSource for StaticApiVMHooksHandler {
         panic!("cannot access the block info in the StaticApi")
     }
 
-    fn back_transfers_lock(&self) -> MutexGuard<BackTransfers> {
+    fn back_transfers_lock(&self) -> MutexGuard<'_, BackTransfers> {
         panic!("cannot access the back transfers in the StaticApi")
     }
 

--- a/vm/src/vm_hooks/vh_source.rs
+++ b/vm/src/vm_hooks/vh_source.rs
@@ -8,7 +8,7 @@ use crate::{
 
 /// Abstracts away the borrowing of a managed types structure.
 pub trait VMHooksHandlerSource: Debug {
-    fn m_types_lock(&self) -> MutexGuard<TxManagedTypes>;
+    fn m_types_lock(&self) -> MutexGuard<'_, TxManagedTypes>;
 
     fn halt_with_error(&self, status: u64, message: &str) -> !;
 
@@ -29,7 +29,7 @@ pub trait VMHooksHandlerSource: Debug {
     /// Random number generator, based on the blockchain randomness source.
     fn random_next_bytes(&self, length: usize) -> Vec<u8>;
 
-    fn result_lock(&self) -> MutexGuard<TxResult>;
+    fn result_lock(&self) -> MutexGuard<'_, TxResult>;
 
     fn push_tx_log(&self, tx_log: TxLog) {
         self.result_lock().result_logs.push(tx_log);
@@ -47,7 +47,7 @@ pub trait VMHooksHandlerSource: Debug {
 
     fn get_current_block_info(&self) -> &BlockInfo;
 
-    fn back_transfers_lock(&self) -> MutexGuard<BackTransfers>;
+    fn back_transfers_lock(&self) -> MutexGuard<'_, BackTransfers>;
 
     /// For ownership reasons, needs to return a clone.
     ///

--- a/vm/src/world_mock/kda_data.rs
+++ b/vm/src/world_mock/kda_data.rs
@@ -156,7 +156,7 @@ impl AccountKda {
             .attributes = new_attribute_bytes;
     }
 
-    pub fn iter(&self) -> Iter<Vec<u8>, KdaData> {
+    pub fn iter(&self) -> Iter<'_, Vec<u8>, KdaData> {
         self.0.iter()
     }
 


### PR DESCRIPTION
This pull request makes a series of improvements across the codebase, primarily by adding explicit lifetime annotations (`'_`) to iterator and reference-returning methods. This change enhances type safety and clarity, making lifetimes more explicit when returning references from methods, and aligns with best practices in modern Rust code. The updates affect various storage mappers, managed types, and synchronization primitives.

The most important changes include:

**Lifetime Annotations**
- Added explicit lifetime parameters to iterator-returning methods. This ensures that returned iterators are properly tied to the lifetime of the source object.

**Miscellaneous Improvements:**
- Made a minor generic specification improvement in the `VMHooksDispatcher` by explicitly specifying the type arguments in a closure.