### PR TITLE
[KLC-1852] Define a fixed rust toolchain version

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install rust
         run: |
-          rustup default stable
+          rustup default 1.89.0
           rustup component add rustfmt clippy
 
       - name: Cargo Cache
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install rust
         run: |
-          rustup default stable
+          rustup default 1.89.0
           rustup target add wasm32-unknown-unknown
 
       - name: Setup koperator
@@ -125,7 +125,7 @@ jobs:
 
       - name: Install rust
         run: |
-          rustup default stable
+          rustup default 1.89.0
           rustup target add wasm32-unknown-unknown
 
       - name: Cargo Cache

--- a/.github/workflows/lldb-formatter-tests.yml
+++ b/.github/workflows/lldb-formatter-tests.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Rust
         run: |
-          rustup default stable
+          rustup default 1.89.0
 
       - name: Download vscode-lldb
         uses: robinraju/release-downloader@v1.5

--- a/.github/workflows/proxy-compare.yml
+++ b/.github/workflows/proxy-compare.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Install Rust
         run: |
-          rustup default stable
+          rustup default 1.89.0
           rustup update
           rustup target add wasm32-unknown-unknown
 

--- a/.github/workflows/release-ksc-cloud.yml
+++ b/.github/workflows/release-ksc-cloud.yml
@@ -65,7 +65,7 @@ jobs:
         shell: bash
         run: |
           # GitHub runners have Rust pre-installed, we just need to add targets
-          rustup default stable
+          rustup default 1.89.0
           rustup target add ${{ matrix.target }}
           
           # For macOS, ensure both targets are available for cross-compilation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Install Rust
         run: |
-          rustup default stable
+          rustup default 1.89.0
           rustup update
           rustup target add ${{ matrix.target }}
 
@@ -235,7 +235,7 @@ jobs:
       
       - name: Install Rust
         run: |
-          rustup default stable
+          rustup default 1.89.0
           rustup update
       
       - name: Cache Cargo registry

--- a/.github/workflows/template-test-current.yml
+++ b/.github/workflows/template-test-current.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install rust
         run: |
-          rustup default stable
+          rustup default 1.89.0
           rustup target add wasm32-unknown-unknown
 
       - name: Setup koperator

--- a/.github/workflows/template-test-released.yml
+++ b/.github/workflows/template-test-released.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install rust
         run: |
-          rustup default stable
+          rustup default 1.89.0
           rustup target add wasm32-unknown-unknown
 
       - name: Setup koperator

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "stable"
+channel = "1.89.0"


### PR DESCRIPTION
This pull request standardizes the Rust toolchain version across all CI workflows and the development environment by explicitly setting it to version 1.89.0 instead of using the generic "stable" channel. This change ensures consistent builds and avoids unexpected issues due to automatic upgrades to newer Rust versions.

**Rust toolchain version update:**

* Updated the `rust-toolchain.toml` file to set the Rust channel to `1.89.0` instead of `stable`.

**CI workflow updates:**

* Changed all occurrences of `rustup default stable` to `rustup default 1.89.0` in the following GitHub Actions workflow files to ensure CI uses the same Rust version:
  * `.github/workflows/actions.yml` [[1]](diffhunk://#diff-2702f6f7d10a1bffbc8596d1a9925b1234bc4c7a6ff4c21ca6b34c13aa75780eL21-R21) [[2]](diffhunk://#diff-2702f6f7d10a1bffbc8596d1a9925b1234bc4c7a6ff4c21ca6b34c13aa75780eL62-R62) [[3]](diffhunk://#diff-2702f6f7d10a1bffbc8596d1a9925b1234bc4c7a6ff4c21ca6b34c13aa75780eL128-R128)
  * `.github/workflows/lldb-formatter-tests.yml`
  * `.github/workflows/proxy-compare.yml`
  * `.github/workflows/release-ksc-cloud.yml`
  * `.github/workflows/release.yml` [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L69-R69) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L238-R238)
  * `.github/workflows/template-test-current.yml`
  * `.github/workflows/template-test-released.yml`